### PR TITLE
Enabled application to launch at startup by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/src/main/__tests__/store.test.ts
+++ b/src/main/__tests__/store.test.ts
@@ -160,7 +160,7 @@ describe("store", () => {
     it("returns defaults when no settings saved", () => {
       const settings = getSettings();
       expect(settings.defaultTimer).toBe("30m");
-      expect(settings.launchAtStartup).toBe(false);
+      expect(settings.launchAtStartup).toBe(true);
       expect(settings.theme).toBe("system");
       expect(settings.downloadsFolder).toBe("C:\\Users\\test\\Downloads");
     });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,6 +36,15 @@ let isQuitting = false;
 
 const isDev = !app.isPackaged;
 
+// ─── Startup helper ───────────────────────────────────────────────────────────
+
+function applyStartupSetting(enabled: boolean): void {
+  app.setLoginItemSettings({
+    openAtLogin: enabled,
+    openAsHidden: true,
+  });
+}
+
 // ─── Window / tray references ─────────────────────────────────────────────────
 
 let mainWindow: BrowserWindow | null = null;
@@ -146,6 +155,10 @@ function registerIpcHandlers(): void {
       startWatcher(mainWindow, updated);
     }
 
+    if (patch.launchAtStartup !== undefined) {
+      applyStartupSetting(patch.launchAtStartup);
+    }
+
     refreshTrayMenu();
     return updated;
   });
@@ -205,6 +218,7 @@ if (!gotLock) {
 
 app.whenReady().then(async () => {
   await initStore();
+  applyStartupSetting(getSettings().launchAtStartup);
   await initDeletionEngine();
 
   createMainWindow();

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -16,7 +16,7 @@ interface StoreSchema {
 function defaultSettings(): UserSettings {
   return {
     downloadsFolder: app.getPath("downloads"),
-    launchAtStartup: false,
+    launchAtStartup: true,
     defaultTimer: "30m",
     customDefaultMinutes: 60,
     theme: "system",


### PR DESCRIPTION
This pull request introduces a change to the application's default settings and improves the handling of the "launch at startup" feature. The default for launching at startup is now set to `true`, and the application will correctly apply this setting both on startup and when the user changes it. Additionally, there are minor improvements to the GitHub issue template for bug reports.

**Launch at Startup Feature Improvements:**

* The default value for `launchAtStartup` in user settings is now `true`, so new users will have the app set to launch at system startup by default. (`src/main/store.ts`, `src/main/__tests__/store.test.ts`) [[1]](diffhunk://#diff-88e4e64eb55c82c552e9516eecdccc5840dbce16f733035c3ef993c0745bc509L19-R19) [[2]](diffhunk://#diff-b187150a4132910aa538a00a91b6cdb4ede39933328f36abf69e81904b2d4da1L163-R163)
* Introduced an `applyStartupSetting` helper function to manage the startup behavior using Electron's `setLoginItemSettings`, ensuring the app launches at login according to the user's settings. (`src/main/index.ts`)
* The startup setting is now applied both when the app initializes and whenever the user updates the setting, keeping the system state in sync with the app's settings. (`src/main/index.ts`) [[1]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR221) [[2]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR158-R161)

**Issue Template Improvements:**

* Minor formatting improvements and additional placeholders were added to the bug report template to make it easier for users to provide relevant information. (`.github/ISSUE_TEMPLATE/bug_report.md`) [[1]](diffhunk://#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5L4-R14) [[2]](diffhunk://#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5R27-R33)

Closes #4 