### PR TITLE
Add middleTruncate utility and integrate into file name displays

### DIFF
--- a/src/renderer/__tests__/format.test.ts
+++ b/src/renderer/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatBytes, formatCountdown, presetToMinutes } from "../utils/format";
+import { formatBytes, formatCountdown, presetToMinutes, middleTruncate } from "../utils/format";
 
 describe("formatBytes", () => {
   it("formats 0 bytes", () => expect(formatBytes(0)).toBe("0 B"));
@@ -36,4 +36,35 @@ describe("presetToMinutes", () => {
   it("30m → 30", () => expect(presetToMinutes("30m")).toBe(30));
   it("2h → 120", () => expect(presetToMinutes("2h")).toBe(120));
   it("1d → 1440", () => expect(presetToMinutes("1d")).toBe(1440));
+});
+
+describe("middleTruncate", () => {
+  it("returns short strings unchanged", () => {
+    expect(middleTruncate("short.txt")).toBe("short.txt");
+  });
+
+  it("returns string exactly at maxLength unchanged", () => {
+    const s = "a".repeat(48);
+    expect(middleTruncate(s)).toBe(s);
+  });
+
+  it("truncates long strings with ellipsis in the middle", () => {
+    const result = middleTruncate("very_long_filename_with_important_info_at_the_end (1).pdf");
+    expect(result).toContain("…");
+    expect(result.startsWith("very_long_filename_with")).toBe(true);
+    expect(result.endsWith("(1).pdf")).toBe(true);
+  });
+
+  it("result length never exceeds maxLength", () => {
+    const long = "a".repeat(100);
+    expect([...middleTruncate(long)].length).toBeLessThanOrEqual(48);
+  });
+
+  it("respects a custom maxLength", () => {
+    const result = middleTruncate("abcdefghijklmnopqrstuvwxyz", 10);
+    expect([...result].length).toBeLessThanOrEqual(10);
+    expect(result).toContain("…");
+    expect(result.startsWith("abcd")).toBe(true);
+    expect(result.endsWith("wxyz")).toBe(true);
+  });
 });

--- a/src/renderer/components/ConfirmDeleteDialog.tsx
+++ b/src/renderer/components/ConfirmDeleteDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { ConfirmDeletePayload } from "../../shared/types";
+import { middleTruncate } from "../utils/format";
 
 interface Props {
   payload: ConfirmDeletePayload;
@@ -60,8 +61,11 @@ export default function ConfirmDeleteDialog({ payload, onDismiss }: Props) {
       aria-label="Confirm file deletion"
     >
       <p className="text-xs text-amber-400 font-medium mb-1">File may be open</p>
-      <p className="text-sm text-neutral-100 truncate mb-1" title={item.fileName}>
-        {item.fileName}
+      <p
+        className="text-sm text-neutral-100 overflow-hidden whitespace-nowrap mb-1"
+        title={item.fileName}
+      >
+        {middleTruncate(item.fileName)}
       </p>
       <p className="text-xs text-neutral-400 mb-3">
         <span className="font-medium text-neutral-300">{processLabel}</span> may have this file

--- a/src/renderer/components/NewFileDialog.tsx
+++ b/src/renderer/components/NewFileDialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { QueueItem } from "../../shared/types";
-import { formatBytes } from "../utils/format";
+import { formatBytes, middleTruncate } from "../utils/format";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -86,8 +86,11 @@ export default function NewFileDialog({ item, onDismiss }: Props) {
       <div className="flex items-start justify-between mb-3">
         <div className="flex-1 min-w-0">
           <p className="text-xs text-neutral-400 mb-0.5">New file detected</p>
-          <p className="text-sm font-medium text-neutral-100 truncate" title={item.fileName}>
-            {item.fileName}
+          <p
+            className="text-sm font-medium text-neutral-100 overflow-hidden whitespace-nowrap"
+            title={item.fileName}
+          >
+            {middleTruncate(item.fileName)}
           </p>
           <p className="text-xs text-neutral-500 mt-0.5">
             {formatBytes(item.fileSize)}

--- a/src/renderer/components/QueueView.tsx
+++ b/src/renderer/components/QueueView.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect, useRef } from "react";
 import { QueueItem, QueueItemStatus } from "../../shared/types";
 import { useQueueStore } from "../store/useQueueStore";
-import { formatBytes, formatCountdown } from "../utils/format";
+import { formatBytes, formatCountdown, middleTruncate } from "../utils/format";
 
 // ─── Status badge ─────────────────────────────────────────────────────────────
 
@@ -290,8 +290,11 @@ export default function QueueView() {
             >
               {/* File info */}
               <div className="flex-1 min-w-0">
-                <p className="text-sm text-neutral-100 truncate" title={item.filePath}>
-                  {item.fileName}
+                <p
+                  className="text-sm text-neutral-100 overflow-hidden whitespace-nowrap"
+                  title={item.filePath}
+                >
+                  {middleTruncate(item.fileName)}
                 </p>
                 <p className="text-xs text-neutral-500 mt-0.5">
                   {formatBytes(item.fileSize)}

--- a/src/renderer/utils/format.ts
+++ b/src/renderer/utils/format.ts
@@ -31,6 +31,18 @@ export function formatCountdown(scheduledFor: number): string {
 }
 
 /**
+ * Truncate a string in the middle, preserving both the start and end.
+ * Useful for filenames where the extension and suffix matter.
+ * e.g. "very_long_filename_info (1).pdf" → "very_long_file…nfo (1).pdf"
+ */
+export function middleTruncate(text: string, maxLength = 48): string {
+  if (text.length <= maxLength) return text;
+  const front = Math.floor((maxLength - 1) / 2);
+  const back = maxLength - 1 - front;
+  return text.slice(0, front) + "…" + text.slice(-back);
+}
+
+/**
  * Convert a timer preset label to minutes.
  */
 export function presetToMinutes(preset: "5m" | "30m" | "2h" | "1d"): number {


### PR DESCRIPTION
This pull request introduces a new utility function, `middleTruncate`, to improve the display of long filenames by truncating them in the middle, preserving both the start and end. The function is thoroughly tested and integrated into several UI components to enhance readability and prevent layout issues caused by overly long filenames.

**New utility and testing:**

* Added the `middleTruncate` function to `src/renderer/utils/format.ts`, which truncates strings in the middle and preserves important suffixes like file extensions.
* Added a comprehensive test suite for `middleTruncate` in `src/renderer/__tests__/format.test.ts`, covering edge cases and custom length handling.

**UI improvements (filename truncation):**

* Updated `ConfirmDeleteDialog.tsx` to use `middleTruncate` for displaying filenames, replacing the previous truncation approach for better readability.
* Modified `NewFileDialog.tsx` to use `middleTruncate` for new file notifications, ensuring filenames are displayed more clearly.
* Enhanced `QueueView.tsx` to apply `middleTruncate` when listing filenames, preventing overflow and maintaining important file information.

**Imports and integration:**

* Updated imports in relevant files to include `middleTruncate` from the utility module. [[1]](diffhunk://#diff-4e31e39afeaa64b4709e70ee50c6a62ac1e6c1d2201e16218494117819d6f371L2-R2) [[2]](diffhunk://#diff-3323553f27343e0a6e65424c0fb49304e4437d13065a96ee22d60ede3a9c7624R3) [[3]](diffhunk://#diff-7129510ddab45c60a30cb5788984080cdd5e88f67740f0d1b172890b2ca032e7L3-R3) [[4]](diffhunk://#diff-c2d9d6660d924a37240935cda0a02febf1205ed61e7cc4e75e570bb65f0f6daeL4-R4)

Closes #7 