### PR TITLE
Add typed IpcResult and document IPC response contract

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -103,7 +103,7 @@ The renderer is treated as an **untrusted boundary**: all data it sends via IPC 
 | `update:install`        | None - calls `quitAndInstall()`            | -                         |
 | `shell:open-external`   | URL allowlisted to repo origin (see §7)    | -                         |
 
-All handlers return `{ success: boolean; error?: string; data?: T }`. The preload bridge checks `success` on every command invocation and throws an `Error` if the main process reports failure, ensuring the renderer can catch and surface errors to the user.
+All invoke handlers use the shared `IpcResult<T>` envelope from `src/shared/types.ts` (`{ success: true; data: T } | { success: false; error: string }`). The preload bridge checks `success` on every command invocation and throws an `Error` if the main process reports failure, ensuring the renderer can catch and surface errors to the user.
 
 ## 4. File System Safety
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -941,6 +941,72 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.78.0",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.78.0.tgz",
@@ -3101,7 +3167,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4834,6 +4900,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4950,7 +5025,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -5521,6 +5596,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
+      "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
+        "electron-winstaller": "5.4.0"
+      }
+    },
     "node_modules/electron-builder/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -5722,6 +5810,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-winstaller": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.1",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "lodash": "^4.17.21",
+        "temp": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@electron/windows-sign": "^1.1.2"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/electron/node_modules/@types/node": {
@@ -8519,6 +8645,20 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mount-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/mount-point/-/mount-point-3.0.0.tgz",
@@ -9309,6 +9449,36 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/powershell-utils": {
       "version": "0.2.0",
       "resolved": "https://registry.npmmirror.com/powershell-utils/-/powershell-utils-0.2.0.tgz",
@@ -9724,6 +9894,21 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/roarr": {
@@ -10381,6 +10566,21 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/temp-file": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -941,72 +941,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@electron/windows-sign": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cross-dirname": "^0.1.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
-        "minimist": "^1.2.8",
-        "postject": "^1.0.0-alpha.6"
-      },
-      "bin": {
-        "electron-windows-sign": "bin/electron-windows-sign.js"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.78.0",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.78.0.tgz",
@@ -3167,7 +3101,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4900,15 +4834,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/cross-dirname": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5025,7 +4950,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -5596,19 +5521,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
-      "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "app-builder-lib": "26.8.1",
-        "builder-util": "26.8.1",
-        "electron-winstaller": "5.4.0"
-      }
-    },
     "node_modules/electron-builder/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -5810,44 +5722,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/electron-winstaller": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
-      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@electron/asar": "^3.2.1",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "lodash": "^4.17.21",
-        "temp": "^0.9.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@electron/windows-sign": "^1.1.2"
-      }
-    },
-    "node_modules/electron-winstaller/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/electron/node_modules/@types/node": {
@@ -8645,20 +8519,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mount-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/mount-point/-/mount-point-3.0.0.tgz",
@@ -9449,36 +9309,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postject": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "commander": "^9.4.0"
-      },
-      "bin": {
-        "postject": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/postject/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/powershell-utils": {
       "version": "0.2.0",
       "resolved": "https://registry.npmmirror.com/powershell-utils/-/powershell-utils-0.2.0.tgz",
@@ -9894,21 +9724,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/roarr": {
@@ -10542,9 +10357,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmmirror.com/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
+      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -10566,21 +10381,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/temp": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
-      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mkdirp": "^0.5.1",
-        "rimraf": "~2.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/temp-file": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,9 @@
     "vite-plugin-electron-renderer": "^0.14.6",
     "vitest": "^4.0.18"
   },
+  "overrides": {
+    "tar": "^7.5.10"
+  },
   "build": {
     "appId": "com.tempdlm.app",
     "productName": "TempDLM",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,11 +3,13 @@ import path from "path";
 import {
   IPC_EVENTS,
   IPC_INVOKE,
+  type QueueItem,
   type UserSettings,
   type SetTimerPayload,
   type CancelPayload,
   type SnoozePayload,
   type ConfirmResponsePayload,
+  type IpcResult,
 } from "../shared/types";
 import { validateSettingsPatch } from "./settingsValidator";
 import {
@@ -228,81 +230,93 @@ function withGuard<T>(
 // ─── IPC handlers ─────────────────────────────────────────────────────────────
 
 function registerIpcHandlers(): void {
-  ipcMain.handle(IPC_INVOKE.QUEUE_GET, () => {
+  ipcMain.handle(IPC_INVOKE.QUEUE_GET, async (): Promise<IpcResult<QueueItem[]>> => {
     return { success: true, data: getQueue() };
   });
 
-  ipcMain.handle(IPC_INVOKE.SETTINGS_GET, () => {
+  ipcMain.handle(IPC_INVOKE.SETTINGS_GET, async (): Promise<IpcResult<UserSettings>> => {
     return { success: true, data: getSettings() };
   });
 
-  ipcMain.handle(IPC_INVOKE.SETTINGS_UPDATE, (_e, patch: Partial<UserSettings>) => {
-    return withGuard("settings:update", () => {
-      const validationError = validateSettingsPatch(patch);
-      if (validationError) {
-        return { success: false, error: validationError };
-      }
+  ipcMain.handle(
+    IPC_INVOKE.SETTINGS_UPDATE,
+    async (_e, patch: Partial<UserSettings>): Promise<IpcResult<UserSettings>> => {
+      return withGuard<IpcResult<UserSettings>>("settings:update", () => {
+        const validationError = validateSettingsPatch(patch);
+        if (validationError) {
+          return { success: false, error: validationError };
+        }
 
-      const prev = getSettings();
-      const updated = patchSettings(patch);
+        const prev = getSettings();
+        const updated = patchSettings(patch);
 
-      // Restart watcher if the downloads folder changed
-      if (mainWindow && patch.downloadsFolder && patch.downloadsFolder !== prev.downloadsFolder) {
-        stopWatcher();
-        startWatcher(mainWindow, updated);
-      }
+        // Restart watcher if the downloads folder changed
+        if (mainWindow && patch.downloadsFolder && patch.downloadsFolder !== prev.downloadsFolder) {
+          stopWatcher();
+          startWatcher(mainWindow, updated);
+        }
 
-      if (patch.launchAtStartup !== undefined) {
-        applyStartupSetting(patch.launchAtStartup);
-      }
+        if (patch.launchAtStartup !== undefined) {
+          applyStartupSetting(patch.launchAtStartup);
+        }
 
-      refreshTrayMenu();
-      return { success: true, data: updated };
-    });
-  });
+        refreshTrayMenu();
+        return { success: true, data: updated };
+      });
+    },
+  );
 
-  ipcMain.handle(IPC_INVOKE.FILE_SET_TIMER, (_e, payload: SetTimerPayload) => {
-    return withGuard(`file:set-timer:${payload.itemId}`, () => {
-      if (!mainWindow) return { success: false, error: "Window not available" };
-      const item = getQueueItem(payload.itemId);
-      if (!item) return { success: false, error: "Item not found" };
-      scheduleItem(item, payload.minutes, mainWindow);
-      mainWindow.webContents.send(IPC_EVENTS.QUEUE_UPDATED, getQueue());
-      refreshTrayMenu();
-      return { success: true };
-    });
-  });
+  ipcMain.handle(
+    IPC_INVOKE.FILE_SET_TIMER,
+    async (_e, payload: SetTimerPayload): Promise<IpcResult> => {
+      return withGuard<IpcResult>(`file:set-timer:${payload.itemId}`, () => {
+        if (!mainWindow) return { success: false, error: "Window not available" };
+        const item = getQueueItem(payload.itemId);
+        if (!item) return { success: false, error: "Item not found" };
+        scheduleItem(item, payload.minutes, mainWindow);
+        mainWindow.webContents.send(IPC_EVENTS.QUEUE_UPDATED, getQueue());
+        refreshTrayMenu();
+        return { success: true, data: undefined };
+      });
+    },
+  );
 
-  ipcMain.handle(IPC_INVOKE.FILE_CANCEL, (_e, payload: CancelPayload) => {
+  ipcMain.handle(IPC_INVOKE.FILE_CANCEL, async (_e, payload: CancelPayload): Promise<IpcResult> => {
     cancelItem(payload.itemId);
     mainWindow?.webContents.send(IPC_EVENTS.QUEUE_UPDATED, getQueue());
     refreshTrayMenu();
-    return { success: true };
+    return { success: true, data: undefined };
   });
 
-  ipcMain.handle(IPC_INVOKE.FILE_SNOOZE, (_e, payload: SnoozePayload) => {
-    return withGuard(`file:snooze:${payload.itemId}`, () => {
+  ipcMain.handle(IPC_INVOKE.FILE_SNOOZE, async (_e, payload: SnoozePayload): Promise<IpcResult> => {
+    return withGuard<IpcResult>(`file:snooze:${payload.itemId}`, () => {
       if (!mainWindow) return { success: false, error: "Window not available" };
       snoozeItem(payload.itemId, mainWindow);
       mainWindow.webContents.send(IPC_EVENTS.QUEUE_UPDATED, getQueue());
       refreshTrayMenu();
-      return { success: true };
+      return { success: true, data: undefined };
     });
   });
 
-  ipcMain.handle(IPC_INVOKE.FILE_REMOVE, (_e, payload: { itemId: string }) => {
-    removeQueueItem(payload.itemId);
-    mainWindow?.webContents.send(IPC_EVENTS.QUEUE_UPDATED, getQueue());
-    refreshTrayMenu();
-    return { success: true };
-  });
+  ipcMain.handle(
+    IPC_INVOKE.FILE_REMOVE,
+    async (_e, payload: { itemId: string }): Promise<IpcResult> => {
+      removeQueueItem(payload.itemId);
+      mainWindow?.webContents.send(IPC_EVENTS.QUEUE_UPDATED, getQueue());
+      refreshTrayMenu();
+      return { success: true, data: undefined };
+    },
+  );
 
-  ipcMain.handle(IPC_INVOKE.FILE_CONFIRM_RESPONSE, (_e, payload: ConfirmResponsePayload) => {
-    resolveConfirmation(payload.itemId, payload.decision);
-    return { success: true };
-  });
+  ipcMain.handle(
+    IPC_INVOKE.FILE_CONFIRM_RESPONSE,
+    async (_e, payload: ConfirmResponsePayload): Promise<IpcResult> => {
+      resolveConfirmation(payload.itemId, payload.decision);
+      return { success: true, data: undefined };
+    },
+  );
 
-  ipcMain.handle("dialog:pick-folder", async () => {
+  ipcMain.handle("dialog:pick-folder", async (): Promise<IpcResult<string | null>> => {
     const result = await dialog.showOpenDialog({
       properties: ["openDirectory"],
       title: "Select Downloads Folder",
@@ -310,7 +324,7 @@ function registerIpcHandlers(): void {
     return { success: true, data: result.canceled ? null : result.filePaths[0] };
   });
 
-  ipcMain.handle(IPC_INVOKE.APP_GET_VERSION, () => {
+  ipcMain.handle(IPC_INVOKE.APP_GET_VERSION, async (): Promise<IpcResult<string>> => {
     return { success: true, data: app.getVersion() };
   });
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from "electron";
 import {
   IPC_EVENTS,
   IPC_INVOKE,
+  type IpcResult,
   type QueueItem,
   type UserSettings,
   type SetTimerPayload,
@@ -16,63 +17,70 @@ import {
 // ─── Exposed API ──────────────────────────────────────────────────────────────
 // This is the only surface the renderer can access from Node/Electron.
 
+function unwrapIpcResult<T>(res: IpcResult<T>): T {
+  if (!res.success) {
+    throw new Error(res.error ?? "Unknown IPC error");
+  }
+  return res.data;
+}
+
 const api = {
   // ── Queries ────────────────────────────────────────────────────────────────
 
   getQueue: async (): Promise<QueueItem[]> => {
-    const res = await ipcRenderer.invoke(IPC_INVOKE.QUEUE_GET);
-    return res.data as QueueItem[];
+    const res = (await ipcRenderer.invoke(IPC_INVOKE.QUEUE_GET)) as IpcResult<QueueItem[]>;
+    return unwrapIpcResult(res);
   },
 
   getSettings: async (): Promise<UserSettings> => {
-    const res = await ipcRenderer.invoke(IPC_INVOKE.SETTINGS_GET);
-    return res.data as UserSettings;
+    const res = (await ipcRenderer.invoke(IPC_INVOKE.SETTINGS_GET)) as IpcResult<UserSettings>;
+    return unwrapIpcResult(res);
   },
 
   // ── Commands ───────────────────────────────────────────────────────────────
 
   setTimer: async (payload: SetTimerPayload): Promise<void> => {
-    const res = await ipcRenderer.invoke(IPC_INVOKE.FILE_SET_TIMER, payload);
-    if (!res.success) throw new Error(res.error ?? "Unknown IPC error");
+    const res = (await ipcRenderer.invoke(IPC_INVOKE.FILE_SET_TIMER, payload)) as IpcResult;
+    unwrapIpcResult(res);
   },
 
   cancelItem: async (payload: CancelPayload): Promise<void> => {
-    const res = await ipcRenderer.invoke(IPC_INVOKE.FILE_CANCEL, payload);
-    if (!res.success) throw new Error(res.error ?? "Unknown IPC error");
+    const res = (await ipcRenderer.invoke(IPC_INVOKE.FILE_CANCEL, payload)) as IpcResult;
+    unwrapIpcResult(res);
   },
 
   snoozeItem: async (payload: SnoozePayload): Promise<void> => {
-    const res = await ipcRenderer.invoke(IPC_INVOKE.FILE_SNOOZE, payload);
-    if (!res.success) throw new Error(res.error ?? "Unknown IPC error");
+    const res = (await ipcRenderer.invoke(IPC_INVOKE.FILE_SNOOZE, payload)) as IpcResult;
+    unwrapIpcResult(res);
   },
 
-  updateSettings: async (
-    settings: Partial<UserSettings>,
-  ): Promise<{ success: boolean; error?: string }> => {
-    const res = await ipcRenderer.invoke(IPC_INVOKE.SETTINGS_UPDATE, settings);
-    return res as { success: boolean; error?: string };
+  updateSettings: async (settings: Partial<UserSettings>): Promise<IpcResult<UserSettings>> => {
+    return (await ipcRenderer.invoke(
+      IPC_INVOKE.SETTINGS_UPDATE,
+      settings,
+    )) as IpcResult<UserSettings>;
   },
 
   removeItem: async (payload: { itemId: string }): Promise<void> => {
-    const res = await ipcRenderer.invoke(IPC_INVOKE.FILE_REMOVE, payload);
-    if (!res.success) throw new Error(res.error ?? "Unknown IPC error");
+    const res = (await ipcRenderer.invoke(IPC_INVOKE.FILE_REMOVE, payload)) as IpcResult;
+    unwrapIpcResult(res);
   },
 
   confirmDeleteResponse: async (payload: ConfirmResponsePayload): Promise<void> => {
-    const res = await ipcRenderer.invoke(IPC_INVOKE.FILE_CONFIRM_RESPONSE, payload);
-    if (!res.success) throw new Error(res.error ?? "Unknown IPC error");
+    const res = (await ipcRenderer.invoke(IPC_INVOKE.FILE_CONFIRM_RESPONSE, payload)) as IpcResult;
+    unwrapIpcResult(res);
   },
 
   pickFolder: async (): Promise<string | null> => {
-    const res = await ipcRenderer.invoke("dialog:pick-folder");
-    return res.data as string | null;
+    const res = (await ipcRenderer.invoke("dialog:pick-folder")) as IpcResult<string | null>;
+    return unwrapIpcResult(res);
   },
 
   // ── Update commands ─────────────────────────────────────────────────────────
 
   getAppVersion: async (): Promise<string> => {
-    const res = await ipcRenderer.invoke(IPC_INVOKE.APP_GET_VERSION);
-    return res.data as string;
+    const res = (await ipcRenderer.invoke(IPC_INVOKE.APP_GET_VERSION)) as IpcResult<string>;
+    return unwrapIpcResult(res);
   },
 
   checkForUpdate: (): Promise<void> => ipcRenderer.invoke(IPC_INVOKE.UPDATE_CHECK),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -71,6 +71,13 @@ export interface UpdateProgress {
   total: number;
 }
 
+// ─── IPC Result ───────────────────────────────────────────────────────────────
+/**
+ * Standard discriminated-union response type for IPC invoke handlers.
+ * @template T - Success payload shape. Defaults to void for command-style IPC.
+ */
+export type IpcResult<T = void> = { success: true; data: T } | { success: false; error: string };
+
 // ─── IPC Channels ────────────────────────────────────────────────────────────
 
 // Main → Renderer events


### PR DESCRIPTION
This pull request standardizes IPC (Inter-Process Communication) responses across the main and renderer processes by introducing a shared `IpcResult<T>` type. This improves error handling, ensures consistent response shapes, and simplifies the codebase by removing ad-hoc result formats. The changes span the main Electron process, preload bridge, shared types, and documentation.

**IPC Response Standardization**

* Added a shared `IpcResult<T>` discriminated-union type in `src/shared/types.ts` to represent IPC handler results consistently.
* Updated all IPC handlers in `src/main/index.ts` to return `IpcResult<T>` and use async functions, ensuring uniform success/error handling. [[1]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeL231-R244) [[2]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeL262-R327)
* Modified the preload bridge in `src/preload/index.ts` to unwrap and handle `IpcResult<T>` responses, throwing errors on failure and returning data on success.

**Documentation Update**

* Updated `docs/security.md` to reference the new `IpcResult<T>` envelope and clarify error handling in the preload bridge.

**Type Imports and Usage**

* Added imports for `IpcResult` and related types in both `src/main/index.ts` and `src/preload/index.ts` to facilitate the new response pattern. [[1]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR6-R12) [[2]](diffhunk://#diff-ab22c748afd4538220cdeba0013847231dc39f27e2b94e71fb21002712d375c0R5)

Closes #44 